### PR TITLE
Fix incorrect NeoVim `keymap.set` setup by adding the missing `{opt}` param back.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ vim.fn["codeium#Accept"]()
 ```
 
 Since this function returns an **expression**, we need to specify it explicitly using `{ expr = true }`.
-Here is an working example for both [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim#specifying-plugins)
+Here is a working example for both [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim#specifying-plugins)
 and [folke/lazy.nvim](https://github.com/folke/lazy.nvim): 
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Here is a working example for both [wbthomason/packer.nvim](https://github.com/w
 and [folke/lazy.nvim](https://github.com/folke/lazy.nvim): 
 
 ```lua
--- Remove the use here if you're using folke/lazy.nvim.
+-- Remove the `use` here if you're using folke/lazy.nvim.
 use {
   'Exafunction/codeium.vim',
   config = function ()

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For a full list of configuration options you can run `:help codeium`.
 
 ### 💻 For Neovim users
 
-You can use the following Lua syntax to access the Vim Script function for auto-completion by this plugin:
+You can use the following Lua code to invoke the Vimscript function for autocompletion by this plugin:
 
 ```lua
 vim.fn["codeium#Accept"]()
@@ -82,7 +82,7 @@ and [folke/lazy.nvim](https://github.com/folke/lazy.nvim):
 use {
   'Exafunction/codeium.vim',
   config = function ()
-    -- Change '<C-g>' here to any keymap you like.
+    -- Change '<C-g>' here to any keycode you like.
     vim.keymap.set('i', '<C-g>', function ()
       return vim.fn['codeium#Accept']()
     end, { expr = true })

--- a/README.md
+++ b/README.md
@@ -67,22 +67,25 @@ For a full list of configuration options you can run `:help codeium`.
 
 ### 💻 For Neovim users
 
-You can use the following Lua code to trigger this plugin:
+You can use the following Lua syntax to access the Vim Script function for auto-completion by this plugin:
 
 ```lua
 vim.fn["codeium#Accept"]()
 ```
 
-and here is an example setup that works with both
-[wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim#specifying-plugins)
-and [folke/lazy.nvim](https://github.com/folke/lazy.nvim) 
-(you will need to remove the `use` for the latter):
+Since this function returns an **expression**, we need to specify it explicitly using `{ expr = true }`.
+Here is an working example for both [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim#specifying-plugins)
+and [folke/lazy.nvim](https://github.com/folke/lazy.nvim): 
 
 ```lua
+-- Remove the use here if you're using folke/lazy.nvim.
 use {
   'Exafunction/codeium.vim',
   config = function ()
-    vim.keymap.set('i', '<C-g>', function () vim.fn['codeium#Accept']() end)
+    -- Change '<C-g>' here to any keymap you like.
+    vim.keymap.set('i', '<C-g>', function ()
+      return vim.fn['codeium#Accept']()
+    end, { expr = true })
   end
 }
 ```


### PR DESCRIPTION
Apologies! My previous PR(#7) is actually incorrect (I thought the mapping was working when I saw the ghost-text preview shown, but I didn't press the keymap :P). This PR fixes that. Again, you might need to help me check my grammar.