### PR TITLE
add better keybinding configuration/documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,66 @@ options, or see [this guide](https://www.codeium.com/vim_tutorial) for a quick t
 
 ## 🛠️ Configuration
 
-### 🖥️ For Vim users
+For a full list of configuration options you can run `:help codeium`.
+A few of the most popular options are highlighted below.
+
+### ⌨️  Keybindings
+
+Codeium provides the following functions to control suggestions:
+
+|Action|Function|Default Binding|
+|---|---|---|
+|Clear current suggestion| `codeium#Clear()` |`<C-]>`|
+|Next suggestion| `codeium#CycleCompletions(1)` |`<M-]>`|
+|Previous suggestion| `codeium#CycleCompletions(-1)` |`<M-[>`|
+|Insert suggestion| `codeium#Accept()` |`<Tab>`|
+|Manually trigger suggestion| `codeium#Complete()` |`<M-Bslash>`|
+
+Codeium's default keybindings can be disabled by setting
+
+```vim
+let g:codeium_disable_bindings = 1
+```
+
+or in Neovim:
+
+```vim
+vim.g.codeium_disable_bindings = 1
+```
+
+If you'd like to just disable the `<Tab>` binding, you can alternatively
+use the `g:codeium_no_map_tab` option.
+
+If you'd like to bind the actions above to different keys, this might look something like the following in Vim:
+
+
+```vim
+imap <C-g>   <Cmd>call codeium#Accept()<CR>
+imap <C-;>   <Cmd>call codeium#CycleCompletions(1)<CR>
+imap <C-,>   <Cmd>call codeium#CycleCompletions(-1)<CR>
+imap <C-x>   <Cmd>call codeium#Clear()<CR>
+```
+
+Or in Neovim (using [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim#specifying-plugins) or [folke/lazy.nvim](https://github.com/folke/lazy.nvim)):
+
+```lua
+-- Remove the `use` here if you're using folke/lazy.nvim.
+use {
+  'Exafunction/codeium.vim',
+  config = function ()
+    -- Change '<C-g>' here to any keycode you like.
+    vim.keymap.set('i', '<C-g>', function () return vim.fn['codeium#Accept']() end, { expr = true })
+    vim.keymap.set('i', '<c-;>', function() return vim.fn['codeium#CycleCompletions'](1) end, { expr = true })
+    vim.keymap.set('i', '<c-,>', function() return vim.fn['codeium#CycleCompletions'](-1) end, { expr = true })
+    vim.keymap.set('i', '<c-x>', function() return vim.fn['codeium#Clear']() end, { expr = true })
+  end
+}
+```
+
+(Make sure that you ran `:Codeium Auth` after installation.)
+
+
+### ⛔ Disabling Codeium
 
 Codeium can be disabled for particular filetypes by setting the
 `g:codeium_filetypes` variable in your vim config file (vimrc/init.vim):
@@ -62,35 +121,6 @@ variable:
 ```vim
 let g:codeium_enabled = v:false
 ```
-
-For a full list of configuration options you can run `:help codeium`.
-
-### 💻 For Neovim users
-
-You can use the following Lua code to invoke the Vimscript function for autocompletion by this plugin:
-
-```lua
-vim.fn["codeium#Accept"]()
-```
-
-Since this function returns an **expression**, we need to specify it explicitly using `{ expr = true }`.
-Here is a working example for both [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim#specifying-plugins)
-and [folke/lazy.nvim](https://github.com/folke/lazy.nvim):
-
-```lua
--- Remove the `use` here if you're using folke/lazy.nvim.
-use {
-  'Exafunction/codeium.vim',
-  config = function ()
-    -- Change '<C-g>' here to any keycode you like.
-    vim.keymap.set('i', '<C-g>', function ()
-      return vim.fn['codeium#Accept']()
-    end, { expr = true })
-  end
-}
-```
-
-(Make sure that you ran `:Codeium Auth` after installation.)
 
 
 ## 💾 Installation Options

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -59,21 +59,24 @@ MAPS                                            *codeium-maps*
                                                 *codeium-i_<Tab>*
 Codeium.vim defaults to using the <Tab> key to insert the current
 suggestion. If there is no suggestion display, the <Tab> key will fallback
-to any existing <Tab> mapping you have.
+to any existing <Tab> mapping you have. This is bound to `codeium#Accept()`
 
 Other Maps ~
 
                                                 *codeium-i_CTRL-]*
 <C-]>                   Dismiss the current suggestion.
 <Plug>(codeium-dismiss)
+<Cmd>call codeium#Clear()<CR>
 
                                                 *codeium-i_ALT-]*
 <M-]>                   Cycle to the next suggestion.
 <Plug>(codeium-next)
+<Cmd>call codeium#CycleCompletions(1)<CR>
 
                                                 *codeium-i_ALT-[*
 <M-[>                   Cycle to the previous suggestion.
 <Plug>(codeium-previous)
+<Cmd>call codeium#CycleCompletions(-1)<CR>
 
 SYNTAX HIGHLIGHTING                             *codeium-highlighting*
 

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -19,7 +19,7 @@ function! s:SetStyle() abort
 endfunction
 
 function! s:MapTab() abort
-  if !get(g:, 'codeium_no_map_tab', v:false)
+  if !get(g:, 'codeium_no_map_tab', v:false) && !get(g:, 'codeium_disable_bindings')
     imap <script><silent><nowait><expr> <Tab> codeium#Accept()
   endif
 endfunction
@@ -36,21 +36,24 @@ augroup codeium
   autocmd VimEnter             * call s:MapTab()
 augroup END
 
-imap <Plug>(codeium-dismiss)     <Cmd>call codeium#Clear()<CR>
-if empty(mapcheck('<C-]>', 'i'))
-  imap <silent><script><nowait><expr> <C-]> codeium#Clear() . "\<C-]>"
-endif
-imap <Plug>(codeium-next)     <Cmd>call codeium#CycleCompletions(1)<CR>
-imap <Plug>(codeium-previous) <Cmd>call codeium#CycleCompletions(-1)<CR>
-imap <Plug>(codeium-complete)  <Cmd>call codeium#Complete()<CR>
-if empty(mapcheck('<M-]>', 'i'))
-  imap <M-]> <Plug>(codeium-next)
-endif
-if empty(mapcheck('<M-[>', 'i'))
-  imap <M-[> <Plug>(codeium-previous)
-endif
-if empty(mapcheck('<M-Bslash>', 'i'))
-  imap <M-Bslash> <Plug>(codeium-complete)
+if !get(g:, 'codeium_disable_bindings')
+  imap <Plug>(codeium-dismiss)     <Cmd>call codeium#Clear()<CR>
+  imap <Plug>(codeium-next)     <Cmd>call codeium#CycleCompletions(1)<CR>
+  imap <Plug>(codeium-previous) <Cmd>call codeium#CycleCompletions(-1)<CR>
+  imap <Plug>(codeium-complete)  <Cmd>call codeium#Complete()<CR>
+
+  if empty(mapcheck('<C-]>', 'i'))
+    imap <silent><script><nowait><expr> <C-]> codeium#Clear() . "\<C-]>"
+  endif
+  if empty(mapcheck('<M-]>', 'i'))
+    imap <M-]> <Plug>(codeium-next)
+  endif
+  if empty(mapcheck('<M-[>', 'i'))
+    imap <M-[> <Plug>(codeium-previous)
+  endif
+  if empty(mapcheck('<M-Bslash>', 'i'))
+    imap <M-Bslash> <Plug>(codeium-complete)
+  endif
 endif
 
 call s:SetStyle()


### PR DESCRIPTION
- Adds documentation for disabling `<Tab>` keybinding to the readme
- Adds ability to disable all keybindings with `g:codeium_disable_bindings`, and adds documentation to readme
- Adds example binding overrides to readme