### PR TITLE
Added codeium#CycleOrComplete() and mapped M-] to it

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -363,6 +363,14 @@ function! codeium#DebouncedComplete(...) abort
   let g:_codeium_timer = timer_start(delay, function('codeium#Complete', [current_buf]))
 endfunction
 
+function! codeium#CycleOrComplete() abort
+  if s:GetCurrentCompletionItem() is v:null
+    call codeium#Complete()
+  else
+    call codeium#CycleCompletions(1)
+  endif
+endfunction
+
 function! codeium#GetStatusString(...) abort
   if (!codeium#Enabled())
     return 'OFF'

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -39,6 +39,7 @@ augroup END
 
 imap <Plug>(codeium-dismiss)     <Cmd>call codeium#Clear()<CR>
 imap <Plug>(codeium-next)     <Cmd>call codeium#CycleCompletions(1)<CR>
+imap <Plug>(codeium-next-or-complete)     <Cmd>call codeium#CycleOrComplete()<CR>
 imap <Plug>(codeium-previous) <Cmd>call codeium#CycleCompletions(-1)<CR>
 imap <Plug>(codeium-complete)  <Cmd>call codeium#Complete()<CR>
 
@@ -47,7 +48,7 @@ if !get(g:, 'codeium_disable_bindings')
     imap <silent><script><nowait><expr> <C-]> codeium#Clear() . "\<C-]>"
   endif
   if empty(mapcheck('<M-]>', 'i'))
-    imap <M-]> <Plug>(codeium-next)
+    imap <M-]> <Plug>(codeium-next-or-complete)
   endif
   if empty(mapcheck('<M-[>', 'i'))
     imap <M-[> <Plug>(codeium-previous)


### PR DESCRIPTION
CycleOrComplete Cycles forward one if there is a completion in place or calls Complete if there is not one.

This allows for behavior similar to C-N for token completion where the user can just launch directly into "next completion" from a state where there is no completion.

