### PR TITLE
handle variable not existing more gracefully

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -407,7 +407,7 @@ function! codeium#RedrawStatusLine() abort
 endfunction
 
 function! codeium#ServerLeave() abort
-  if g:codeium_server_job is v:null
+  if !get(g: ,'codeium_server_job')
     return
   endif
 


### PR DESCRIPTION
If I start nvim with nvim +commnd +q to update it from the cli for example, the global variable might be not yet set when we reach the exit function so it will cause an error: undefined variable codeium_server_job

Using `get` handle this case, it returns 0 when the variable is not set yet instead of an error

My actual use case is updating lunarvim from the cli with `lvim +LvimUpdate +q` 