### PR TITLE
don't start language server if codeium is disabled

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -15,7 +15,7 @@ let s:default_codeium_enabled = {
       \ '.': 0}
 
 function! codeium#Enabled() abort
-  if !get(g:, 'codeium_enabled', v:true) || !get(b:, 'codeium_enabled', v:true)
+  if !get(g:, 'codeium_enabled', v:true)
     return v:false
   endif
 

--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -15,7 +15,7 @@ let s:default_codeium_enabled = {
       \ '.': 0}
 
 function! codeium#Enabled() abort
-  if !get(g:, 'codeium_enabled', v:true)
+  if !get(g:, 'codeium_enabled', v:true) || !get(b:, 'codeium_enabled', v:true)
     return v:false
   endif
 

--- a/autoload/codeium/command.vim
+++ b/autoload/codeium/command.vim
@@ -126,9 +126,8 @@ function! s:commands.DisableBuffer(...) abort
   let b:codeium_enabled = 0
 endfunction
 
-" Run codeium server if not already started
-" FIXME: share this with codeium.vim
-function! s:start_language_server()
+" Run codeium server only if its not already started
+function! codeium#command#StartLanguageServer() abort
   if !get(g:, 'codeium_server_started', v:false)
     call timer_start(0, function('codeium#server#Start'))
     let g:codeium_server_started = v:true
@@ -137,12 +136,12 @@ endfunction
 
 function! s:commands.Enable(...) abort
   let g:codeium_enabled = 1
-  call s:start_language_server()
+  call codeium#command#StartLanguageServer()
 endfunction
 
 function! s:commands.EnableBuffer(...) abort
   let b:codeium_enabled = 1
-  call s:start_language_server()
+  call codeium#command#StartLanguageServer()
 endfunction
 
 function! codeium#command#ApiKey() abort
@@ -167,3 +166,4 @@ function! codeium#command#Command(arg) abort
     return ''
   endif
 endfunction
+

--- a/autoload/codeium/command.vim
+++ b/autoload/codeium/command.vim
@@ -126,12 +126,23 @@ function! s:commands.DisableBuffer(...) abort
   let b:codeium_enabled = 0
 endfunction
 
+" Run codeium server if not already started
+" FIXME: share this with codeium.vim
+function! s:start_language_server()
+  if !get(g:, 'codeium_server_started', v:false)
+    call timer_start(0, function('codeium#server#Start'))
+    let g:codeium_server_started = v:true
+  endif
+endfunction
+
 function! s:commands.Enable(...) abort
   let g:codeium_enabled = 1
+  call s:start_language_server()
 endfunction
 
 function! s:commands.EnableBuffer(...) abort
   let b:codeium_enabled = 1
+  call s:start_language_server()
 endfunction
 
 function! codeium#command#ApiKey() abort

--- a/autoload/codeium/command.vim
+++ b/autoload/codeium/command.vim
@@ -166,4 +166,3 @@ function! codeium#command#Command(arg) abort
     return ''
   endif
 endfunction
-

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -61,17 +61,8 @@ endif
 
 call s:SetStyle()
 
-" Run codeium server if not already started
-" FIXME: share this with command.vim
-function! s:start_language_server()
-  if !get(g:, 'codeium_server_started', v:false)
-    call timer_start(0, function('codeium#server#Start'))
-    let g:codeium_server_started = v:true
-  endif
-endfunction
-
 if g:codeium_enabled
-  call s:start_language_server()
+  call codeium#command#StartLanguageServer()
 endif
 
 let s:dir = expand('<sfile>:h:h')
@@ -81,7 +72,7 @@ endif
 
 function! CodeiumEnable()  " Enable Codeium if it is disabled
   let g:codeium_enabled = v:true
-  call s:start_language_server()
+  call codeium#command#StartLanguageServer()
 endfun
 
 command! CodeiumEnable :silent! call CodeiumEnable()

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -61,7 +61,7 @@ endif
 
 call s:SetStyle()
 
-if g:codeium_enabled
+if codeium#Enabled()
   call codeium#command#StartLanguageServer()
 endif
 

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -61,10 +61,17 @@ endif
 
 call s:SetStyle()
 
+" Run codeium server if not already started
+" FIXME: share this with command.vim
+function! s:start_language_server()
+  if !get(g:, 'codeium_server_started', v:false)
+    call timer_start(0, function('codeium#server#Start'))
+    let g:codeium_server_started = v:true
+  endif
+endfunction
+
 if g:codeium_enabled
-  call timer_start(0, function('codeium#server#Start'))
-  " Make sure to start codeium server only once
-  let g:codeium_server_started = true
+  call s:start_language_server()
 endif
 
 let s:dir = expand('<sfile>:h:h')
@@ -74,11 +81,7 @@ endif
 
 function! CodeiumEnable()  " Enable Codeium if it is disabled
   let g:codeium_enabled = v:true
-  if !get(g:, 'codeium_server_started', v:false)
-    call timer_start(0, function('codeium#server#Start'))
-    " Make sure to start codeium server only once
-    let g:codeium_server_started = true
-  endif
+  call s:start_language_server()
 endfun
 
 command! CodeiumEnable :silent! call CodeiumEnable()

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -60,7 +60,12 @@ if !get(g:, 'codeium_disable_bindings')
 endif
 
 call s:SetStyle()
-call timer_start(0, function('codeium#server#Start'))
+
+if g:codeium_enabled
+  call timer_start(0, function('codeium#server#Start'))
+  " Make sure to start codeium server only once
+  let g:codeium_server_started = true
+endif
 
 let s:dir = expand('<sfile>:h:h')
 if getftime(s:dir . '/doc/codeium.txt') > getftime(s:dir . '/doc/tags')
@@ -69,6 +74,11 @@ endif
 
 function! CodeiumEnable()  " Enable Codeium if it is disabled
   let g:codeium_enabled = v:true
+  if !get(g:, 'codeium_server_started', v:false)
+    call timer_start(0, function('codeium#server#Start'))
+    " Make sure to start codeium server only once
+    let g:codeium_server_started = true
+  endif
 endfun
 
 command! CodeiumEnable :silent! call CodeiumEnable()


### PR DESCRIPTION
Currently codeium langue server is always started even when vim.g.codeium_enabled is set to false

This pr changes that to make it not start if its codeium is disabled, and it will start automatically once the user uses `CodeiumEnable`

The reason for this for me personally 1) I prefer to disable codeium by default and only enabled for specific projects 2) there is a significant nvim startup time hit from starting the server

I don't know vimscript that much (I used codeium for help xD)  so help is appreciated to improve the code if the pr is accepted