### PR TITLE
Add g:codeium_tab_fallback documentation

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -37,10 +37,11 @@ function! codeium#CompletionText() abort
 endfunction
 
 function! codeium#Accept() abort
-  if mode() !~# '^[iR]' || !exists('b:_codeium_completions')
-    return "\t"
-  endif
   let default = get(g:, 'codeium_tab_fallback', pumvisible() ? "\<C-N>" : "\t")
+
+  if mode() !~# '^[iR]' || !exists('b:_codeium_completions')
+    return default
+  endif
 
   let current_completion = s:GetCurrentCompletionItem()
   if current_completion is v:null

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -68,6 +68,13 @@ g:codeium_idle_delay    Delay in milliseconds before autocompletions are
                         let g:codeium_idle_delay = 500
 <
 
+                                                *g:codeium_tab_fallback*
+g:codeium_tab_fallback  The fallback key when there is no suggestion display
+                        in `codeium#Accept()`.
+>
+                        let g:codeium_tab_fallback = "\t"
+<
+
 MAPS                                            *codeium-maps*
 
                                                 *codeium-i_<Tab>*


### PR DESCRIPTION
I have added `g:codeium_tab_fallback documentation` documentation.