### PR TITLE
feat(server): add filter arm64 while install server

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -122,7 +122,7 @@ endfunction
 function! codeium#server#Start(...) abort
   let os = substitute(system('uname'), '\n', '', '')
   let arch = substitute(system('uname -m'), '\n', '', '')
-  let is_arm = stridx(arch, 'arm') == 0 || stridx(arch, 'aarch64') == 0
+  let is_arm = stridx(arch, 'arm') == 0 || stridx(arch, 'aarch64') == 0 || stridx(arch, 'arm64') == 0
 
   if os ==# 'Linux' && is_arm
     let bin_suffix = 'linux_arm'


### PR DESCRIPTION
I'm using mbp m2 and I faced wrong server download (its windows_x64.exe) problem, so in my locale I updated like this