### PR TITLE
Added branch main for vim plug installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ For vim-airline extension you can use following config:
 ### 🔌 vim-plug
 
 ```vim
-Plug 'Exafunction/codeium.vim'
+Plug 'Exafunction/codeium.vim', { 'branch': 'main' }
 ```
 
 ### 📦 Vundle


### PR DESCRIPTION
Vim plug uses `master` by default. To fix this we can point it to the custom default branch name that `codeium.vim` GitHub is configured with.