### PR TITLE
silence non-interactive system() calls

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -120,8 +120,8 @@ function! s:SendHeartbeat(timer) abort
 endfunction
 
 function! codeium#server#Start(...) abort
-  let os = substitute(system('uname'), '\n', '', '')
-  let arch = substitute(system('uname -m'), '\n', '', '')
+  silent let os = substitute(system('uname'), '\n', '', '')
+  silent let arch = substitute(system('uname -m'), '\n', '', '')
   let is_arm = stridx(arch, 'arm') == 0 || stridx(arch, 'aarch64') == 0
 
   if os ==# 'Linux' && is_arm


### PR DESCRIPTION
Control characters can leak onto the screen in some configurations (observed with vim on linux with some terminals). `:help system` says to prepend calls with `silent` to prevent that.

There are some other `system()` calls in the codebase which could maybe use this treatment but I'm not going to go changing them without being able to reproduce the same issue. Eg I did `rm -r ~/.codeium/bin/*` and restarted vim and the binary was put back and there was no garbage on the screen. :shrug: 

Fixes: #83
Fixes: #126