### PR TITLE
fix: Fix completion eating characters when using multi-byte character

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -62,10 +62,12 @@ function! codeium#Accept() abort
 
   let delete_range = ''
   if end_offset - start_offset > 0
-      " We insert a space, escape to normal mode, then delete the inserted space.
-      " This lets us "accept" any auto-inserted indentation which is otherwise
-      " removed when we switch to normal mode.
-    let delete_range = " \<Esc>x0d" . (end_offset - start_offset) . 'li'
+    let delete_bytes = end_offset - start_offset
+    let delete_chars = strchars(strpart(getline('.'), 0, delete_bytes))
+    " We insert a space, escape to normal mode, then delete the inserted space.
+    " This lets us "accept" any auto-inserted indentation which is otherwise
+    " removed when we switch to normal mode.
+    let delete_range = " \<Esc>x0d" . delete_chars . 'li'
   endif
 
   let insert_text = "\<C-R>\<C-O>=codeium#CompletionText()\<CR>"


### PR DESCRIPTION
## Reproduce

Before:
![image](https://github.com/Exafunction/codeium.vim/assets/1709861/a8bac100-1b24-43c9-8ce7-1c7e8db921b4)
After completion:
![image](https://github.com/Exafunction/codeium.vim/assets/1709861/0b0b5e70-a6c3-4263-8f92-e9f48ecfeda2)

This PR fixes a bug when completing after a Multi-Byte character (https://en.wikipedia.org/wiki/DBCS, https://en.wikipedia.org/wiki/DBCS).