### PR TITLE
error handling for missing `gzip`

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -182,6 +182,10 @@ function! s:UnzipAndStart(status) abort
     let &shellcmdflag = old_shellcmdflag
     let &shellredir = old_shellredir
   else
+    if !executable('gzip')
+      call codeium#log#Error('Failed to extract language server binary: missing `gzip`.')
+      return ''
+    endif
     call system('gzip -d ' . s:bin . '.gz')
     call system('chmod +x ' . s:bin)
   endif


### PR DESCRIPTION
(re #220) Adding log because it's an edge case that normally shouldn't happen - all POSIX compliant systems should have `gzip` installed (that includes all Linux and MacOS instances).