### PR TITLE
Describe vim-airline support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,7 @@ Shorter variant without Codeium logo:
 
 Please check `:help statusline` for further information about building statusline in VIM.
 
-For vim-airline extension you can use following config:
-
-```let g:airline_section_y = '{…}%3{codeium#GetStatusString()}'```
+vim-airline supports Codeium out-of-the-box since commit [3854429d](https://github.com/vim-airline/vim-airline/commit/3854429d99c8a2fb555a9837b155f33c957a2202).
 
 ## 💾 Installation Options
 


### PR DESCRIPTION
Vim-airline has out-of-the-box support for Codeium, so no extra configuration is needed.