### PR TITLE
Add new variable: `g:codeium_filetypes_disabled_by_default`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ If you would like to just disable the automatic triggering of completions:
 
 ```vim
 let g:codeium_manual = v:true
+
+" You might want to use `CycleOrComplete()` instead of `CycleCompletions(1)`.
+" This will make the forward cycling of suggestions also trigger the first
+" suggestion manually.
+imap <C-;> <Cmd>call codeium#CycleOrComplete()<CR>
 ```
 
 To disable automatic text rendering of suggestions (the gray text that appears for a suggestion):

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ let g:codeium_filetypes = {
 
 Codeium is enabled by default for most filetypes.
 
-You can also _disable_ codeium by default with the `g:codeium_enabled`
-variable:
+You can also _disable_ codeium by default with the `g:codeium_enabled` variable,
+and enable it manually per buffer by running `:CodeiumEnable`:
 
 ```vim
 let g:codeium_enabled = v:false
@@ -127,8 +127,20 @@ or in Neovim:
 vim.g.codeium_enabled = false
 ```
 
-Instead, if you would like to just disable the automatic triggering of
-completions:
+Or you can disable codeium for _all filetypes_ with the `g:codeium_filetypes_disabled_by_default` variable,
+and use the `g:codeium_filetypes` variable to selectively enable codeium for specified filetypes:
+
+```vim
+" let g:codeium_enabled = v:true
+let g:codeium_filetypes_disabled_by_default = v:true
+
+let g:codeium_filetypes = {
+    \ "rust": v:true,
+    \ "typescript": v:true,
+    \ }
+```
+
+If you would like to just disable the automatic triggering of completions:
 
 ```vim
 let g:codeium_manual = v:true

--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -21,7 +21,13 @@ function! codeium#Enabled() abort
 
   let codeium_filetypes = s:default_codeium_enabled
   call extend(codeium_filetypes, get(g:, 'codeium_filetypes', {}))
-  if !get(codeium_filetypes, &filetype, 1)
+  " The `''` filetype should be forced to `1`, otherwise codeium may be unable start.
+  " This is related to the default new empty file not setting a filetype.
+  call extend(codeium_filetypes, {'': 1})
+
+  let codeium_filetypes_disabled_by_default = get(g:, 'codeium_filetypes_disabled_by_default') || get(b:, 'codeium_filetypes_disabled_by_default')
+
+  if !get(codeium_filetypes, &filetype, !codeium_filetypes_disabled_by_default)
     return v:false
   endif
 


### PR DESCRIPTION
Enables finer control for when codeium is enabled by adding the `g:codeium_filetypes_disabled_by_default` variable.

It disables _all filetypes_ by default, and makes it possible to use the `g:codeium_filetypes` variable to selectively enable codeium for specified filetypes:

```vim
" let g:codeium_enabled = v:true
let g:codeium_filetypes_disabled_by_default = v:true

let g:codeium_filetypes = {
    \ "rust": v:true,
    \ "typescript": v:true,
    \ }
```

An alternative way to handle this issue would be to make `g:codeium_enabled = v:false` respect `g:codeium_filetypes`, meaning i.e. if `"rust"` is  `v:true`, then we start codeium for that buffer, even if codeium is disabled. I guess this alternative would be a breaking change.