### PR TITLE
Feat: Add codeium_ls_binary option

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -122,6 +122,14 @@ function! s:SendHeartbeat(timer) abort
 endfunction
 
 function! codeium#server#Start(...) abort
+  let user_defined_codeium_bin = get(g:, 'codeium_bin', '')
+
+  if user_defined_codeium_bin != '' && filereadable(user_defined_codeium_bin)
+    let s:bin = user_defined_codeium_bin
+    call s:ActuallyStart()
+    return
+  endif
+
   silent let os = substitute(system('uname'), '\n', '', '')
   silent let arch = substitute(system('uname -m'), '\n', '', '')
   let is_arm = stridx(arch, 'arm') == 0 || stridx(arch, 'aarch64') == 0

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -86,6 +86,14 @@ g:codeium_tab_fallback  The fallback key when there is no suggestion display
 >
                         let g:codeium_tab_fallback = "\t"
 <
+                                                *g:codeium_bin*
+g:codeium_bin           Manually set the path to the `codeium` language server
+                        binary on your system.
+                        If unset, `codeium.vim` will fetch and download the
+                        binary from the internet.
+>
+                        let g:codeium_bin = "~/.local/bin/codeium_language_server"
+<
 
 MAPS                                            *codeium-maps*
 


### PR DESCRIPTION
This patch adds an option which lets the user specify the path to the codeium language server binary.
This can be very useful for users who have already installed `codeium` on their system and would like to use it from the `codeium.vim` plugin.

Note: There might be a better option name for this !