### PR TITLE
add how-to install on nixos

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,4 @@ Run the following. On windows, you can replace `~/.config` with
 ```bash
 git clone https://github.com/Exafunction/codeium.vim ~/.config/nvim/pack/Exafunction/start/codeium.vim
 ```
+#### NixOS


### PR DESCRIPTION
Hello! I hope this finds you well.
Could a README section on how to install with nix be composed?

codeium is available on nixpkgs, however installing it I get an error described in 
https://github.com/Exafunction/codeium.vim/issues/159
which refers to 
https://github.com/Exafunction/codeium.vim/pull/149

The explanation isn't understandable by me without some research, I will try to figure it out and add a short notice to the fellow NixOS users.

Thanks!



