### PR TITLE
Typo: lower vs upper case

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -443,7 +443,7 @@ function! codeium#AddTrackedWorkspace() abort
   endif
   let s:codeium_workspace_indexed = v:true
   try
-    call codeium#server#Request('AddTrackedWorkspace', {"workspace": s:getProjectRoot()})
+    call codeium#server#Request('AddTrackedWorkspace', {"workspace": s:GetProjectRoot()})
   catch
     call codeium#log#Exception()
   endtry


### PR DESCRIPTION
This didn't affect me with Vim 9.0 patch 1-1413 so I didn't notice it, but it did affect another user now.