### PR TITLE
Feat: add codeium_os and codeium_arch options

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -129,9 +129,16 @@ function! codeium#server#Start(...) abort
     call s:ActuallyStart()
     return
   endif
+  let user_defined_os = get(g:, 'codeium_os', '')
+  let user_defined_arch = get(g:, 'codeium_arch', '')
 
-  silent let os = substitute(system('uname'), '\n', '', '')
-  silent let arch = substitute(system('uname -m'), '\n', '', '')
+  if user_defined_os != '' && user_defined_arch != ''
+    let os = user_defined_os
+    let arch = user_defined_arch
+  else
+    silent let os = substitute(system('uname'), '\n', '', '')
+    silent let arch = substitute(system('uname -m'), '\n', '', '')
+  endif
   let is_arm = stridx(arch, 'arm') == 0 || stridx(arch, 'aarch64') == 0
 
   if os ==# 'Linux' && is_arm

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -93,21 +93,21 @@ g:codeium_bin           Manually set the path to the `codeium` language server
                         binary from the internet.
 >
                         let g:codeium_bin = "~/.local/bin/codeium_language_server"
-
-*g:codeium_os
+<
+                                                *g:codeium_os*
 g:codeium_os            Manually set the host OS, accepted values are
                         "Linux", "Darwin", "Windows". if unset, the value will
-                        be taken using `uname`.
+                        be obtained using `uname`.
 >
                         let g:codeium_os = "Linux"
-
-*g:codeium_arch
+<
+                                                *g:codeium_arch*
 g:codeium_arch          Manually set the host architecture, accepted values
                         are "x86_64", "aarch64", "arm". If unset, the value
-                        will be taken using `uname -m`.
+                        will be obtained using `uname -m`.
 >
                         let g:codeium_arch = "x86_64"
-
+<
 MAPS                                            *codeium-maps*
 
                                                 *codeium-i_<Tab>*

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -93,7 +93,20 @@ g:codeium_bin           Manually set the path to the `codeium` language server
                         binary from the internet.
 >
                         let g:codeium_bin = "~/.local/bin/codeium_language_server"
-<
+
+*g:codeium_os
+g:codeium_os            Manually set the host OS, accepted values are
+                        "Linux", "Darwin", "Windows". if unset, the value will
+                        be taken using `uname`.
+>
+                        let g:codeium_os = "Linux"
+
+*g:codeium_arch
+g:codeium_arch          Manually set the host architecture, accepted values
+                        are "x86_64", "aarch64", "arm". If unset, the value
+                        will be taken using `uname -m`.
+>
+                        let g:codeium_arch = "x86_64"
 
 MAPS                                            *codeium-maps*
 


### PR DESCRIPTION
Calling system("uname") twice on startup is very slow,
instead let us set the os and arch options manually, and call system() only when needed

This will also help neovim users as they can use vim.uv.os_uname() function which executes much faster.