### PR TITLE
Modify `StartLanguageServer` to be called conditionally on `BufEnter`.

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -21,9 +21,6 @@ function! codeium#Enabled() abort
 
   let codeium_filetypes = s:default_codeium_enabled
   call extend(codeium_filetypes, get(g:, 'codeium_filetypes', {}))
-  " The `''` filetype should be forced to `1`, otherwise codeium may be unable start.
-  " This is related to the default new empty file not setting a filetype.
-  call extend(codeium_filetypes, {'': 1})
 
   let codeium_filetypes_disabled_by_default = get(g:, 'codeium_filetypes_disabled_by_default') || get(b:, 'codeium_filetypes_disabled_by_default')
 

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -27,6 +27,7 @@ endfunction
 augroup codeium
   autocmd!
   autocmd InsertEnter,CursorMovedI,CompleteChanged * call codeium#DebouncedComplete()
+  autocmd BufEnter     * if codeium#Enabled()|call codeium#command#StartLanguageServer()|endif
   autocmd BufEnter     * if mode() =~# '^[iR]'|call codeium#DebouncedComplete()|endif
   autocmd InsertLeave  * call codeium#Clear()
   autocmd BufLeave     * if mode() =~# '^[iR]'|call codeium#Clear()|endif
@@ -60,10 +61,6 @@ if !get(g:, 'codeium_disable_bindings')
 endif
 
 call s:SetStyle()
-
-if codeium#Enabled()
-  call codeium#command#StartLanguageServer()
-endif
 
 let s:dir = expand('<sfile>:h:h')
 if getftime(s:dir . '/doc/codeium.txt') > getftime(s:dir . '/doc/tags')


### PR DESCRIPTION
This is related to PR #252

Forcing the filetype `''` to `1` had the unintended side-effect of always enabling codeium for new empty buffers when using `codeium_filetypes_disabled_by_default`.

Now that we conditionally run `StartLanguageServer` on `BufEnter`, we don't need to separately call it during startup.

(As `StartLanguageServer`'s contents are wrapped by a check of `codeium_server_started`, we don't need to worry about multiple server starts.)