### PR TITLE
feat: accept next word and next line completions.

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -94,8 +94,12 @@ endfunction
 
 function! codeium#AcceptNextWord() abort
   let current_completion = s:GetCurrentCompletionItem()
-  let prefix_text = get(current_completion.completionParts[0], 'prefix', '')
-  let completion_text = get(current_completion.completionParts[0], 'text', '')
+  let completion_parts = get(current_completion, 'completionParts', [])
+  if len(completion_parts) == 0
+    return ''
+  endif
+  let prefix_text = get(completion_parts[0], 'prefix', '')
+  let completion_text = get(completion_parts[0], 'text', '')
   let next_word = matchstr(completion_text, '\v^\W*\k*')
   return s:CompletionInserter(current_completion, prefix_text . next_word)
 endfunction

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -58,6 +58,12 @@ if !get(g:, 'codeium_disable_bindings')
   if empty(mapcheck('<M-Bslash>', 'i'))
     imap <M-Bslash> <Plug>(codeium-complete)
   endif
+  if empty(mapcheck('<C-Right>', 'i'))
+    imap <script><silent><nowait><expr> <C-Right> codeium#AcceptNextWord()
+  endif
+  if empty(mapcheck('<Right>', 'i'))
+    imap <script><silent><nowait><expr> <Right> codeium#AcceptNextLine()
+  endif
 endif
 
 call s:SetStyle()


### PR DESCRIPTION
The process of inserting suggestions is always roughly the same, so
abstracted that into the `s:CompletionInserter` function.

With that, I refactored `codeium#Accept` (maintaining the same functionality) and introduced
`codeium#AcceptNextWord` and `codeium#AcceptNextLine`. Fixes #27
