### PR TITLE
fix(#381): handle when there are no completions

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -94,6 +94,9 @@ endfunction
 
 function! codeium#AcceptNextWord() abort
   let current_completion = s:GetCurrentCompletionItem()
+  if current_completion is v:null
+    return ''
+  endif
   let completion_parts = get(current_completion, 'completionParts', [])
   if len(completion_parts) == 0
     return ''
@@ -106,6 +109,9 @@ endfunction
 
 function! codeium#AcceptNextLine() abort
   let current_completion = s:GetCurrentCompletionItem()
+  if current_completion is v:null
+    return ''
+  endif
   let text = substitute(current_completion.completion.text, '\v\n.*$', '', '')
   return s:CompletionInserter(current_completion, text)
 endfunction


### PR DESCRIPTION
Will not error nor insert anything when the functions are called and
there are no completions yet.
