### PR TITLE
fix: redrawstatus in insert cause indent wrongly in neovim

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -522,7 +522,9 @@ function! codeium#GetStatusString(...) abort
 endfunction
 
 function! codeium#RedrawStatusLine() abort
-  if s:using_codeium_status
+  if has('nvim') && s:using_codeium_status
+    lua vim.schedule(vim.cmd.redrawstatus)
+  elseif s:using_codeium_status
     redrawstatus
   endif
 endfunction


### PR DESCRIPTION
The behavior is:

When press `o` to enter insert mode, the cursor will be wrongly indented.