### PR TITLE
Set a high priority on virtual text in Neovim 

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -239,8 +239,11 @@ function! s:RenderCurrentCompletion() abort
     endif
 
     if has('nvim')
+      " Set priority high so that completions appear above LSP inlay hints
+      let priority = get(b:, 'codeium_virtual_text_priority',
+                  \ get(g:, 'codeium_virtual_text_priority', 65535))
       let _virtcol = virtcol([row, _col+diff])
-      let data = {'id': idx + 1, 'hl_mode': 'combine', 'virt_text_win_col': _virtcol - 1}
+      let data = {'id': idx + 1, 'hl_mode': 'combine', 'virt_text_win_col': _virtcol - 1, 'priority': priority }
       if part.type ==# 'COMPLETION_PART_TYPE_INLINE_MASK'
         let data.virt_text = [[text, s:hlgroup]]
       elseif part.type ==# 'COMPLETION_PART_TYPE_BLOCK'

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -108,6 +108,30 @@ g:codeium_arch          Manually set the host architecture, accepted values
 >
                         let g:codeium_arch = "x86_64"
 <
+                                                *g:codeium_virtual_text_priority*
+g:codeium_virtual_text_priority
+                        The priority used for Codeium's virtual text completions
+                        in Neovim. This can control how completions appear when
+                        multiple virtual text items are on the same line, such
+                        as when using LSP inlay hints.
+
+                        The priority can be set on a per-buffer basis by setting
+                        the b:codeium_virtual_text_priority variable. If
+                        neither of these are set, the default priority is 65535,
+                        which will usually place it above any other virtual text.
+>
+                        let g:codeium_virtual_text_priority = 1000
+<
+
+                                                *b:codeium_virtual_text_priority*
+b:codeium_virtual_text_priority
+                        The priority given to Codeium's virtual text completions
+                        for the current buffer in Neovim. If not set,
+                        g:codeium_virtual_text_priority is used.
+>
+                        let b:codeium_virtual_text_priority = 1000
+<
+
 MAPS                                            *codeium-maps*
 
                                                 *codeium-i_<Tab>*


### PR DESCRIPTION
This allows the suggestions to appear on top of coc.nvim inlay hints and other virtual text on the same line, whereas with the default priority they appear below the inlay hint which makes the suggestions difficult to read.

Without setting priority, we see the `bool` inlay hint appears on top of the `empty();` suggestion.  (My theme is set up so that Codeium's suggestions are in light red.)

![CleanShot 2024-07-25 at 15 28 30@2x](https://github.com/user-attachments/assets/977f8e35-f19f-4dab-9f4b-760deefcb05c)

The same line with the change in this PR. Codeium's suggestion appears above the inlay hint, so it can be read.

![CleanShot 2024-07-25 at 15 29 44@2x](https://github.com/user-attachments/assets/4a7f262b-92ae-4ca8-ac50-fdaa1f3c1f27)


Tested with Neovim 0.10.1
