### PR TITLE
fix(server): protect against responses with no status

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -123,7 +123,7 @@ function! s:HandleGetStatusResponse(out, err, status) abort
   if a:status == 0
     " Parse the JSON response
     let response = json_decode(join(a:out, "\n"))
-    let status = response.status
+    let status = get(response, 'status', {})
     " Check if there is a message in the response and echo it
     if has_key(status, 'message') && !empty(status.message)
       echom status.message


### PR DESCRIPTION
I noticed when I'm working offline I get some errors regarding accessing this `status` variable. This adds protection to make sure it doesn't error out.