### PR TITLE
fix: when vim-plug lazy loading, tab cannot be successfully completed

### DIFF
--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -66,6 +66,7 @@ if !get(g:, 'codeium_disable_bindings')
   endif
 endif
 
+call s:MapTab()
 call s:SetStyle()
 
 let s:dir = expand('<sfile>:h:h')


### PR DESCRIPTION
# problem
When I load this plugin with vim-plug and lazy load, I find that it can complete but can't press tab to complete.Its completion is normal, but tab can not be used, it is obvious that the key mapping problem
![图片](https://github.com/user-attachments/assets/c5b2267f-3dec-4a52-89cb-5a3b63c2cbca)
# why to change
The problem is that maptab is called after autocmd vimenter, but lazy loading does not trigger vimenter events, so it needs to be called directly from the plugin folder. This method is also called in the same way in copilot.vim except in the vimenter and plugin folder again, so I think it's appropriate to add this call
![图片](https://github.com/user-attachments/assets/1b3f01fe-875a-4d3e-99e8-2d0c3cadd38d)


