### PR TITLE
Add vim command to call the chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ vim-airline supports Codeium out-of-the-box since commit [3854429d](https://gith
 
 Calling the `codeium#Chat()` function will enable search and indexing in the current project and launch Codeium Chat in a new browser window.
 
+```vim
+:call codeium#Chat()
+```
+
 The project root is determined by looking in Vim's current working directory for some specific files or directories to be present and goes up to parent directories until one is found.  This list of hints is user-configurable and the default value is:
 
 ```let g:codeium_workspace_root_hints = ['.bzr','.git','.hg','.svn','_FOSSIL_','package.json']```


### PR DESCRIPTION
The section on how to launch Codeium chat is lacking the actual command to call it. Looking at the comment at https://github.com/Exafunction/codeium.vim/issues/118#issuecomment-2011977947, we can see that this is not necessarily obvious.