### PR TITLE
Add support for WSL

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -162,6 +162,14 @@ function! codeium#server#Start(...) abort
   endif
   let is_arm = stridx(arch, 'arm') == 0 || stridx(arch, 'aarch64') == 0
 
+  if empty(os)
+    if has("linux")
+      let os = "Linux"
+    elseif has("darwin")
+      let os = "Darwin"
+    endif
+  endif
+
   if os ==# 'Linux' && is_arm
     let bin_suffix = 'linux_arm'
   elseif os ==# 'Linux'

--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -165,7 +165,7 @@ function! codeium#server#Start(...) abort
   if empty(os)
     if has("linux")
       let os = "Linux"
-    elseif has("darwin")
+    elseif has("mac")
       let os = "Darwin"
     endif
   endif


### PR DESCRIPTION
For some reason, `system("uname")` returns an empty string. I added a check for this.

This also resolves #433

There are errors printed now, but that is from the server when unauthorized.