### PR TITLE
specify chat and web ports

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -252,6 +252,7 @@ endfunction
 
 function! s:ActuallyStart() abort
   let config = get(g:, 'codeium_server_config', {})
+  let chat_ports = get(g:, 'codeium_ports', {})
   let manager_dir = tempname() . '/codeium/manager'
   call mkdir(manager_dir, 'p')
 
@@ -265,6 +266,14 @@ function! s:ActuallyStart() abort
   if has_key(config, 'api_url') && !empty(config.api_url)
     let args += ['--enterprise_mode']
     let args += ['--portal_url', get(config, 'portal_url', 'https://codeium.example.com')]
+  endif
+  " If either of these is set, only one vim window (with any number of buffers) will work with Codeium.
+  " Opening other vim windows won't be able to use Codeium features. 
+  if has_key(chat_ports, 'web_server') && !empty(chat_ports.web_server)
+    let args += ['--chat_web_server_port', chat_ports.web_server]
+  endif
+  if has_key(chat_ports, 'chat_client') && !empty(chat_ports.chat_client)
+    let args += ['--chat_client_port', chat_ports.chat_client]
   endif
 
   call codeium#log#Info('Launching server with manager_dir ' . manager_dir)

--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -252,7 +252,7 @@ endfunction
 
 function! s:ActuallyStart() abort
   let config = get(g:, 'codeium_server_config', {})
-  let chat_ports = get(g:, 'codeium_ports', {})
+  let chat_ports = get(g:, 'codeium_port_config', {})
   let manager_dir = tempname() . '/codeium/manager'
   call mkdir(manager_dir, 'p')
 

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -108,6 +108,21 @@ g:codeium_arch          Manually set the host architecture, accepted values
 >
                         let g:codeium_arch = "x86_64"
 <
+                                                *g:codeium_port_config*
+g:codeium_port_config
+                        Set the ports the chat client and web server use. 
+			Pass in web_server and chat_client fields to the mapping to set.
+                        Please note that if either of the ports are specified, only one 
+			window will work with codeium. 
+			That window can have as many buffers within it, but any other 
+			opened windows will not be able to use Codeium's features.
+>
+                        let g:codeium_port_config = {
+				'web_server': <Your web server port>,
+				'chat_client': <Your chat client port>
+				}
+<
+
                                                 *g:codeium_virtual_text_priority*
 g:codeium_virtual_text_priority
                         The priority used for Codeium's virtual text completions


### PR DESCRIPTION
Someone wanted to specify the chat and webserver ports. This allows that. 
Not ideal in that it limits Codeium to one window, because every window starts its own ls and so if those hardcoded ports are busy it won't work. 
However, as many tabs/buffers within that window are fine. 