### PR TITLE
add vim command for invoking chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,11 @@ vim-airline supports Codeium out-of-the-box since commit [3854429d](https://gith
 
 ### Launching Codeium Chat
 
-Calling the `codeium#Chat()` function will enable search and indexing in the current project and launch Codeium Chat in a new browser window.
+Calling the `codeium#Chat()` function or using the `Codeium Chat` command will enable search and indexing in the current project and launch Codeium Chat in a new browser window.
 
 ```vim
 :call codeium#Chat()
+:Codeium Chat
 ```
 
 The project root is determined by looking in Vim's current working directory for some specific files or directories to be present and goes up to parent directories until one is found.  This list of hints is user-configurable and the default value is:

--- a/autoload/codeium/command.vim
+++ b/autoload/codeium/command.vim
@@ -137,6 +137,10 @@ function! s:commands.Auth(...) abort
   endif
 endfunction
 
+function s:commands.Chat(...) abort
+  call codeium#Chat()
+endfunction
+
 function! s:commands.Disable(...) abort
   let g:codeium_enabled = 0
 endfunction

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -13,6 +13,9 @@ COMMANDS                                        *:Codeium*
                                                 *:Codeium_Auth*
 :Codeium Auth           Authenticate to Codeium.
 
+                                                *:Codeium_Chat*
+:Codeium Chat           Open Codeium Chat in a browser window
+
                                                 *:Codeium_Disable*
 :Codeium Disable        Disable Codeium completions
 

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -108,8 +108,15 @@ endfun
 
 command! CodeiumAuto :silent! call CodeiumAuto()
 
+function! CodeiumChat()
+  call codeium#Chat()
+endfun
+
+command! CodeiumChat :silent! call CodeiumChat()
+
 :amenu Plugin.Codeium.Enable\ \Codeium\ \(\:CodeiumEnable\) :call CodeiumEnable() <Esc>
 :amenu Plugin.Codeium.Disable\ \Codeium\ \(\:CodeiumDisable\) :call CodeiumDisable() <Esc>
 :amenu Plugin.Codeium.Manual\ \Codeium\ \AI\ \Autocompletion\ \(\:CodeiumManual\) :call CodeiumManual() <Esc>
 :amenu Plugin.Codeium.Automatic\ \Codeium\ \AI\ \Completion\ \(\:CodeiumAuto\) :call CodeiumAuto() <Esc>
 :amenu Plugin.Codeium.Toggle\ \Codeium\ \(\:CodeiumToggle\) :call CodeiumToggle() <Esc>
+:amenu Plugin.Codeium.Chat\ \Codeium\ \(\:CodeiumChat\) :call CodeiumChat() <Esc>


### PR DESCRIPTION
This allows using `CodeiumChat` and `Codeium Chat` commands as an easier way to start chat.

Resolves #434 