### PR TITLE
Fix RefreshContextForIdeAction call to pass correct column

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -473,7 +473,7 @@ endfunction
 function! codeium#RefreshContext() abort
   " current buffer is 1
   try
-    call codeium#server#Request('RefreshContextForIdeAction', {'active_document': codeium#doc#GetDocument(1, line('.'), line('.'))})
+    call codeium#server#Request('RefreshContextForIdeAction', {'active_document': codeium#doc#GetDocument(1, line('.'), col('.'))})
   catch
     call codeium#log#Exception()
   endtry


### PR DESCRIPTION
Fixes this error which I saw in the diagnostics (added newlines for readability):

```
E1002 15:51:49.912757 76190 interceptor.go:51] 
/exa.language_server_pb.LanguageServerService/RefreshContextForIdeAction: 
invalid position (row 258, col 258): character 258 out of range [0, 18] for line 258
```

This call happens when opening chat, so it may fix an issue where Codeium Chat doesn't always properly know the context right away, but I haven't explicitly tested that.