### PR TITLE
Fix LS port if codeium_port_config is set

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -508,8 +508,7 @@ function! codeium#Chat() abort
     call codeium#AddTrackedWorkspace()
     " If user has chat_ports set, they are probably using vim remotely and trying to use chat via port forwarding.
     " In that case display the url here so that it is easier to copy, as the browser will fail to open automatically. 
-    let chat_ports = get(g:, 'codeium_port_config', {})
-    if has_key(chat_ports, 'chat_client') && !empty(chat_ports.chat_client) && has_key(chat_ports, 'web_server') && !empty(chat_ports.web_server)
+    if codeium#util#IsUsingRemoteChat()
       let l:metadata = codeium#server#RequestMetadata()
       let l:url = BuildChatUrl(l:metadata, chat_ports.chat_client, chat_ports.web_server)
       echomsg l:url

--- a/autoload/codeium/util.vim
+++ b/autoload/codeium/util.vim
@@ -8,3 +8,8 @@ function! codeium#util#HasSupportedVersion() abort
 
   return s:nvim_virt_text_support || s:vim_virt_text_support
 endfunction
+
+function! codeium#util#IsUsingRemoteChat() abort
+  let chat_ports = get(g:, 'codeium_port_config', {})
+  return has_key(chat_ports, 'chat_client') && !empty(chat_ports.chat_client) && has_key(chat_ports, 'web_server') && !empty(chat_ports.web_server)
+endfunction


### PR DESCRIPTION
LS port is needed for @ mentions to work. Removing the manager_dir arg  when starting the ls fixes it at 42100, so users can reliable forward three ports to get chat to work remotely 