### PR TITLE
fix: restore shell options when aborts

### DIFF
--- a/autoload/codeium/server.vim
+++ b/autoload/codeium/server.vim
@@ -238,14 +238,17 @@ function! s:UnzipAndStart(status) abort
     set shellquote= shellpipe=\| shellxquote=
     set shellcmdflag=-NoLogo\ -NoProfile\ -ExecutionPolicy\ RemoteSigned\ -Command
     set shellredir=\|\ Out-File\ -Encoding\ UTF8
-    call system('& { . ' . shellescape(s:root . '/powershell/gzip.ps1') . '; Expand-File ' . shellescape(s:bin . '.gz') . ' }')
-    " Restore old settings.
-    let &shell = old_shell
-    let &shellquote = old_shellquote
-    let &shellpipe = old_shellpipe
-    let &shellxquote = old_shellxquote
-    let &shellcmdflag = old_shellcmdflag
-    let &shellredir = old_shellredir
+    try
+      call system('& { . ' . shellescape(s:root . '/powershell/gzip.ps1') . '; Expand-File ' . shellescape(s:bin . '.gz') . ' }')
+    finally
+      " Restore old settings.
+      let &shell = old_shell
+      let &shellquote = old_shellquote
+      let &shellpipe = old_shellpipe
+      let &shellxquote = old_shellxquote
+      let &shellcmdflag = old_shellcmdflag
+      let &shellredir = old_shellredir
+    endtry
   else
     if !executable('gzip')
       call codeium#log#Error('Failed to extract language server binary: missing `gzip`.')


### PR DESCRIPTION
To ensure that the `shell` settings are restored even if the `system` command fails.
I need this change because `system` failed in fact, but the reason for the failure is not addressed in this PR.