### PR TITLE
Add ability to exclude files from context

### DIFF
--- a/autoload/codeium.vim
+++ b/autoload/codeium.vim
@@ -364,7 +364,7 @@ function! codeium#Complete(...) abort
   let current_bufnr = bufnr('%')
   let loaded_buffers = getbufinfo({'bufloaded':1})
   for buf in loaded_buffers
-    if buf.bufnr != current_bufnr && getbufvar(buf.bufnr, '&filetype') !=# ''
+    if buf.bufnr != current_bufnr && getbufvar(buf.bufnr, '&filetype') !=# '' && ! getbufvar(buf.bufnr, 'codeium_excluded')
       call add(other_documents, codeium#doc#GetDocument(buf.bufnr, 1, 1))
     endif
   endfor

--- a/doc/codeium.txt
+++ b/doc/codeium.txt
@@ -29,6 +29,10 @@ COMMANDS                                        *:Codeium*
 :Codeium EnableBuffer   Re-enable Codeium completions in the current
                         buffer after running :Codeium DisableBuffer
 
+                                                *:Codeium_ExcludeBuffer*
+:Codeium ExcludeBuffer  Exclude current buffer from codeium completion
+                        contexts
+
                                                 *:Codeium_Toggle*
 :Codeium Toggle         Enable Codeium completions if they are disabled.
                         Disable Codeium completions if they are enabled. Does
@@ -151,6 +155,16 @@ b:codeium_virtual_text_priority
                         g:codeium_virtual_text_priority is used.
 >
                         let b:codeium_virtual_text_priority = 1000
+<
+
+                                                          *b:codeium_excluded*
+b:codeium_excluded
+                        Buffer-local flag that controls whether the buffer is
+                        excluded from codeium's context. If not set, buffer
+                        is included as context as default. Set it to `v:true`
+                        to exclude the buffer from context.
+>
+                        let b:codeium_excluded = v:true
 <
 
 MAPS                                            *codeium-maps*

--- a/plugin/codeium.vim
+++ b/plugin/codeium.vim
@@ -96,6 +96,12 @@ endfunction
 
 command! CodeiumToggle :silent! call CodeiumToggle()
 
+function! CodeiumExclude() " Exclude current buffer from Codeium context
+  let b:codeium_excluded = v:false
+endfun
+
+command! CodeiumExclude :silent! call CodeiumExclude()
+
 function! CodeiumManual() " Disable the automatic triggering of completions
   let g:codeium_manual = v:true
 endfun


### PR DESCRIPTION
Codeium can make vim laggy in insert mode if a huge file (>10 MB) is opened and added as a completion context in vim. This PR adds the command `:CodeiumExclude` and a new buffer-local flag `b:codeium_excluded` to exclude specific files (e.g. large files) from codeium's context.