### PR TITLE
fix the workflow to run normally

### DIFF
--- a/.github/workflows/version_tag_action.yaml
+++ b/.github/workflows/version_tag_action.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get version from file
         id: version
-        run: echo ::set-output name=version::$(grep -oP "(?<=s:language_server_version = ')[^']+" autoload/codeium/server.vim)
+        run: echo version=$(grep -oP "(?<=s:language_server_version = ')[^']+" autoload/codeium/server.vim) >> $GITHUB_OUTPUT
       - name: Check if tag exists
         id: add_tag
         run: |

--- a/.github/workflows/version_tag_action.yaml
+++ b/.github/workflows/version_tag_action.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get version from file
         id: version
-        run: echo version=$(grep -oP "(?<=s:language_server_version = ')[^']+" autoload/codeium/server.vim) >> $GITHUB_OUTPUT
+        run: echo version=$(grep -oP "(?<=s:language_server_version = ')[^']+" autoload/codeium/server.vim | head -n1) >> $GITHUB_OUTPUT
       - name: Check if tag exists
         id: add_tag
         run: |


### PR DESCRIPTION
This PR addresses two issues:

-   Deprecated `::set-output` command has been removed.
    See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
-   Limited the number of server versions retrieved to one, resolving a workflow failure introduced by a8d47ec54fe82df920b2545559f767003e8a7f8d.